### PR TITLE
Implement transcript scoring logic

### DIFF
--- a/grading.py
+++ b/grading.py
@@ -1,0 +1,36 @@
+"""Transcript grading utilities."""
+from __future__ import annotations
+from typing import Optional
+
+
+def compute_transcript_score(
+    *,
+    wer: float,
+    multilingual_accuracy: float,
+    speaker_f1: Optional[float] = None,
+    multilingual_support: bool = True,
+) -> float:
+    """Return a 0-1000 score summarising transcript quality."""
+
+    # Base weights
+    phrase_weight = 0.8
+    multilingual_weight = 0.1
+    diarisation_weight = 0.1
+
+    if speaker_f1 is None:
+        # Reallocate diarisation weight to phrase accuracy
+        phrase_weight += diarisation_weight
+        diarisation_weight = 0.0
+
+    phrase_score = max(0.0, 1.0 - wer) * (phrase_weight * 1000)
+    multilingual_score = multilingual_accuracy * (multilingual_weight * 1000)
+    speaker_score = (speaker_f1 or 0.0) * (diarisation_weight * 1000)
+
+    overall = phrase_score + multilingual_score + speaker_score
+
+    # Cap if multilingual accuracy is poor or system lacks support
+    if not multilingual_support or multilingual_accuracy < 0.5:
+        overall = min(overall, 500)
+
+    # Clamp final score
+    return max(0.0, min(1000.0, overall))

--- a/grading_system.md
+++ b/grading_system.md
@@ -1,0 +1,49 @@
+# Transcript Grading System (0-1000 Score)
+
+This document proposes a scoring framework for evaluating ASR transcripts against a corrected reference.
+
+## Overview
+- **Purpose**: Provide a single numeric score (0–1000) to summarise transcript quality.
+- **Inputs**:
+  - Generated transcript(s) from the tool.
+  - Reference transcript with manually corrected text.
+  - Optional diarisation metadata.
+- **Outputs**:
+  - `overall_score` in the range 0–1000.
+  - Breakdown of component sub-scores (WER, diarisation, language handling).
+
+## Scoring Components
+The overall score is composed of three parts:
+
+1. **Phrase Accuracy (80% weight)**
+   - Measured using Word Error Rate (WER) between the combined transcript and reference.
+   - `phrase_score = max(0, 1 - WER) * 800`.
+2. **Multilingual Handling (10% weight)**
+   - Determines whether the system correctly transcribes lines in multiple languages.
+   - Use `language_utils.identify_spanish_lines` (and similar heuristics for other languages) on both reference and predicted transcripts.
+   - Compute the fraction of correctly identified multilingual lines and scale to 100 points.
+   - **Gate**: If multilingual accuracy is below 50%, the final score cannot exceed 500.
+3. **Diarisation Accuracy (10% weight)**
+   - Optional speaker-turn accuracy if diarisation metadata is provided.
+   - Compute F1 score of speaker boundaries compared with reference. Scale to 100 points.
+   - If no diarisation info is available, allocate the full 100 points to phrase accuracy instead.
+
+The `overall_score` is the sum of the three component scores, capped between 0 and 1000.  Systems that do not support multilingual transcription are capped at 500 regardless of other metrics.
+
+## Example Calculation
+```
+WER = 0.15  # 15% word error
+multilingual_accuracy = 0.85
+speaker_f1 = 0.70
+
+phrase_score      = (1 - 0.15) * 800 = 680
+multilingual_score = 0.85 * 100       = 85
+speaker_score      = 0.70 * 100       = 70
+
+overall = phrase_score + multilingual_score + speaker_score
+        = 835  (no cap triggered)
+```
+
+## Usage in Experiments
+Whenever `transcribe_and_evaluate.py` is run, compute the three metrics and print the resulting score alongside WER.  Future scripts can log these values to compare models and configurations.
+

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -1,0 +1,20 @@
+import unittest
+from grading import compute_transcript_score
+
+
+class TestGrading(unittest.TestCase):
+    def test_example_score(self):
+        score = compute_transcript_score(wer=0.15, multilingual_accuracy=0.85, speaker_f1=0.70)
+        self.assertAlmostEqual(score, 835, delta=0.1)
+
+    def test_multilingual_gate(self):
+        score = compute_transcript_score(wer=0.1, multilingual_accuracy=0.4, speaker_f1=0.9)
+        self.assertLessEqual(score, 500)
+
+    def test_no_diarisation(self):
+        score = compute_transcript_score(wer=0.0, multilingual_accuracy=1.0, speaker_f1=None)
+        self.assertEqual(score, 1000)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/transcribe_and_evaluate.py
+++ b/transcribe_and_evaluate.py
@@ -44,6 +44,7 @@ import logging
 import re
 
 from language_utils import identify_spanish_lines
+from grading import compute_transcript_score
 
 # Suppress HF generation warnings
 hf_logging.set_verbosity_error()
@@ -180,8 +181,20 @@ def main() -> None:
     ref_spanish = set(identify_spanish_lines(ref_lines))
     pred_spanish = set(identify_spanish_lines(pred_lines))
     if ref_spanish:
-        accuracy = len(ref_spanish & pred_spanish) / len(ref_spanish)
-        logging.info("Spanish line detection accuracy: %.2f%%", accuracy * 100)
+        multilingual_accuracy = len(ref_spanish & pred_spanish) / len(ref_spanish)
+    else:
+        multilingual_accuracy = 1.0
+    logging.info(
+        "Spanish line detection accuracy: %.2f%%",
+        multilingual_accuracy * 100,
+    )
+
+    overall = compute_transcript_score(
+        wer=error_rate,
+        multilingual_accuracy=multilingual_accuracy,
+        speaker_f1=None,
+    )
+    logging.info("Overall transcript score: %.1f/1000", overall)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `compute_transcript_score` helper
- integrate scoring into the transcription script
- unit tests for scoring behaviour

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*